### PR TITLE
Missing dep on rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,12 +16,14 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>roslib</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>message_generation</build_depend>
 
   <run_depend>std_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>roslib</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>message_runtime</run_depend>
 


### PR DESCRIPTION
Ran into this issue while build ROS from source using the new [catkin build](catkin-tools.readthedocs.org)

See http://answers.ros.org/question/39523/rospackagegetpath-problem/
